### PR TITLE
Minimal update to make it work on newest VkFFT and Rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.idea/

--- a/crates/vkfft-sys/.vscode/settings.json
+++ b/crates/vkfft-sys/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "C_Cpp.default.includePath": [
     "${env:VKFFT_ROOT}/vkFFT",
-    "${env:VKFFT_ROOT}/glslang-master/glslang/Include",
+    "${env:VKFFT_ROOT}/glslang-main/glslang/Include",
   ],
   "C_Cpp.default.defines": [
     "VKFFT_BACKEND=0"

--- a/crates/vkfft-sys/build.rs
+++ b/crates/vkfft-sys/build.rs
@@ -114,10 +114,10 @@ fn main() -> Result<(), Box<dyn Error>> {
   let out_dir = PathBuf::from(out_dir);
 
   let library_dirs = [
-    format!("{}/build/glslang-master/glslang", vkfft_root),
-    format!("{}/build/glslang-master/glslang/OSDependent/Unix", vkfft_root),
-    format!("{}/build/glslang-master/glslang/OGLCompilersDLL", vkfft_root),
-    format!("{}/build/glslang-master/glslang/SPIRV", vkfft_root),
+    format!("{}/build/glslang-main/glslang", vkfft_root),
+    format!("{}/build/glslang-main/glslang/OSDependent/Unix", vkfft_root),
+    format!("{}/build/glslang-main/glslang/OGLCompilersDLL", vkfft_root),
+    format!("{}/build/glslang-main/SPIRV", vkfft_root),
   ];
 
   let libraries = [
@@ -144,7 +144,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
   let include_dirs = [
     format!("{}/vkFFT", &vkfft_root),
-    format!("{}/glslang-master/glslang/Include", vkfft_root)
+    format!("{}/glslang-main/glslang/Include", vkfft_root)
   ];
 
   let defines = [

--- a/examples/convolution.rs
+++ b/examples/convolution.rs
@@ -158,7 +158,7 @@ pub fn convolve(
   Ok(())
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
   println!("VkFFT version: {}", vkfft::version());
 
   let instance = Instance::new(
@@ -167,7 +167,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
       ext_debug_utils: true,
       ..InstanceExtensions::none()
     },
-    vec!["VK_LAYER_KHRONOS_validation"],
+    None,
   )?;
 
   let mut context = Context::new(&instance)?;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/config.rs
+++ b/src/config.rs
@@ -605,8 +605,8 @@ impl<'a> Config<'a> {
           .map(|b| b.inner().buffer.internal_object().value()),
       });
 
-      res.config.FFTdim = self.fft_dim;
-      res.config.size = self.size;
+      res.config.FFTdim = self.fft_dim as u64;
+      res.config.size = self.size.map(u64::from);
 
       res.config.physicalDevice = transmute(addr_of_mut!(res.physical_device));
       res.config.device = transmute(addr_of_mut!(res.device));
@@ -670,12 +670,12 @@ impl<'a> Config<'a> {
       res.config.performZeropadding[1] = self.zero_padding[1].into();
       res.config.performZeropadding[2] = self.zero_padding[2].into();
 
-      res.config.fft_zeropad_left = self.zeropad_left;
-      res.config.fft_zeropad_right = self.zeropad_right;
+      res.config.fft_zeropad_left = self.zeropad_left.map(u64::from);
+      res.config.fft_zeropad_right = self.zeropad_right.map(u64::from);
 
       res.config.kernelConvolution = self.kernel_convolution.into();
       res.config.performR2C = self.r2c.into();
-      res.config.coordinateFeatures = self.coordinate_features;
+      res.config.coordinateFeatures = self.coordinate_features as u64;
       res.config.disableReorderFourStep = self.disable_reorder_four_step.into();
 
       res.config.symmetricKernel = self.symmetric_kernel.into();
@@ -711,7 +711,7 @@ impl<'a> Config<'a> {
       }
 
       if let Some(batch_count) = &self.batch_count {
-        res.config.numberBatches = *batch_count;
+        res.config.numberBatches = *batch_count as u64;
       }
 
       Ok(res)

--- a/src/version.rs
+++ b/src/version.rs
@@ -33,8 +33,8 @@ pub fn version() -> Version {
   let ver = unsafe { vkfft_sys::VkFFTGetVersion() };
 
   Version {
-    major: ver / 10000,
-    minor: ver % 10000 / 100,
-    patch: ver % 100,
+    major: (ver / 10000) as u32,
+    minor: (ver % 10000 / 100) as u32,
+    patch: (ver % 100) as u32,
   }
 }


### PR DESCRIPTION
Hi, I know these bindings haven't been updated in a while, but I wanted to play around with it and there were a few issues that made it impossible to run, primarily because glslang switches from "master" to "main", but also some changes in the binding generation, requiring u64 instead of u32 in some places. 

Also, the inclusion of 'vec!["VK_LAYER_KHRONOS_validation"],' as a layer in the Vulkano instance gives a very opaque error. The example runs fine when just using None, so I used that instead.

Thanks for these bindings!